### PR TITLE
DPI-2832: Pack plotly in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "plotly";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = "Create interactive web graphics from 'ggplot2' graphs and/or a custom interface to the (MIT-licensed) JavaScript library 'plotly.js' inspired by the grammar of graphics.";
+  propagatedBuildInputs = with pkgs.rPackages; [ tools scales httr jsonlite magrittr digest viridisLite base64enc htmltools htmlwidgets tidyr RColorBrewer dplyr vctrs tibble lazyeval rlang crosstalk purrr data_table promises ];
+
+}

--- a/package.nix
+++ b/package.nix
@@ -5,6 +5,28 @@ pkgs.rPackages.buildRPackage {
   version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
   src = ./.;
   description = "Create interactive web graphics from 'ggplot2' graphs and/or a custom interface to the (MIT-licensed) JavaScript library 'plotly.js' inspired by the grammar of graphics.";
-  propagatedBuildInputs = with pkgs.rPackages; [ tools scales httr jsonlite magrittr digest viridisLite base64enc htmltools htmlwidgets tidyr RColorBrewer dplyr vctrs tibble lazyeval rlang crosstalk purrr data_table promises ];
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    ggplot2
+    scales 
+    httr 
+    jsonlite 
+    magrittr 
+    digest 
+    viridisLite 
+    base64enc 
+    htmltools 
+    htmlwidgets 
+    tidyr 
+    RColorBrewer 
+    dplyr 
+    vctrs 
+    tibble 
+    lazyeval 
+    rlang 
+    crosstalk 
+    purrr 
+    data_table 
+    promises 
+  ];
 
 }


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package plotly in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR